### PR TITLE
feature: faking logux requests without webmock

### DIFF
--- a/lib/logux/test.rb
+++ b/lib/logux/test.rb
@@ -2,7 +2,33 @@
 
 module Logux
   module Test
+    class << self
+      attr_accessor :http_requests_enabled
+
+      def enable_http_requests!
+        raise ArgumentError unless block_given?
+
+        begin
+          self.http_requests_enabled = true
+          yield
+        ensure
+          self.http_requests_enabled = false
+        end
+      end
+    end
+
+    module Client
+      def post(params)
+        if Logux::Test.http_requests_enabled
+          super(params)
+        else
+          Logux::Test::Store.instance.add(params.to_json)
+        end
+      end
+    end
+
     autoload :Helpers, 'logux/test/helpers'
     autoload :Store, 'logux/test/store'
   end
 end
+Logux::Client.prepend Logux::Test::Client

--- a/lib/logux/test/store.rb
+++ b/lib/logux/test/store.rb
@@ -5,25 +5,16 @@ module Logux
     class Store
       include Singleton
 
-      def add_request(action)
-        parsed_body = parse_body(action[:request]&.body)
-        requests << action.merge(body: parsed_body)
+      def add(params)
+        data << params
       end
 
-      def requests
-        @requests ||= []
+      def data
+        @data ||= []
       end
 
       def reset!
-        @requests = []
-      end
-
-      private
-
-      def parse_body(body)
-        JSON.parse(body)
-      rescue JSON::ParserError, TypeError
-        {}
+        @data = []
       end
     end
   end

--- a/spec/logux_spec.rb
+++ b/spec/logux_spec.rb
@@ -6,12 +6,12 @@ describe Logux, timecop: true do
   end
 
   describe '.add' do
-    before { described_class.add(type) }
-
     let(:type) { [] }
 
     it 'makes request' do
-      expect(WebMock).to have_requested(:post, Logux.configuration.logux_host)
+      stub = stub_request(:post, Logux.configuration.logux_host)
+      Logux::Test.enable_http_requests! { described_class.add(type) }
+      expect(stub).to have_been_requested
     end
   end
 


### PR DESCRIPTION
Suppose, that by default Logux::Test patches the Logux::Client not to do post requests, but if it is really needed - we could disable this behavour