### PR TITLE
Add better reply for unknown action and subscriptions (alternative implementation)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,6 @@ FactoryBot/StaticAttributeDefinedDynamically:
 
 RSpec/ExpectChange:
   EnforcedStyle: block
+
+Style/RescueStandardError:
+  EnforcedStyle: implicit

--- a/app/controllers/logux_controller.rb
+++ b/app/controllers/logux_controller.rb
@@ -3,7 +3,6 @@
 class LoguxController < ActionController::Base
   include ActionController::Live
 
-  # rubocop:disable Style/RescueStandardError
   def create
     Logux.verify_request_meta_data(meta_params)
     logux_stream.write('[')
@@ -13,13 +12,12 @@ class LoguxController < ActionController::Base
       Logux.configuration.on_error.call(e)
       Logux.logger.error("#{e}\n#{e.backtrace.join("\n")}")
     ensure
-      logux_stream.write([:error].to_json)
+      logux_stream.write(Logux::ErrorRenderer.new(e).message)
     end
   ensure
     logux_stream.write(']')
     logux_stream.close
   end
-  # rubocop:enable Style/RescueStandardError
 
   private
 

--- a/lib/logux/action_caller.rb
+++ b/lib/logux/action_caller.rb
@@ -15,6 +15,9 @@ module Logux
       action_class = class_finder.find_action_class
       @action_controller = action_class.new(action: action, meta: meta)
       format(action_controller.public_send(action.action_type))
+    rescue Logux::UnknownActionError, Logux::UnknownChannelError => e
+      Logux.logger.warn(e)
+      format(nil)
     end
 
     private
@@ -26,7 +29,7 @@ module Logux
     end
 
     def class_finder
-      @class_finder ||= Logux::ClassFinder.new(action)
+      @class_finder ||= Logux::ClassFinder.new(action: action, meta: meta)
     end
   end
 end

--- a/lib/logux/error_renderer.rb
+++ b/lib/logux/error_renderer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Logux
+  class ErrorRenderer
+    attr_reader :exception
+
+    def initialize(exception)
+      @exception = exception
+    end
+
+    def message
+      case exception
+      when Logux::WithMetaError
+        build_message(exception, exception.meta.id)
+      when Logux::UnauthorizedError
+        build_message(exception, exception.message)
+      when StandardError
+        # some runtime error that should be fixed
+        ['error', 'Please look server logs for more information']
+      end
+    end
+
+    private
+
+    def build_message(exception, additional_info)
+      [
+        exception.class.name.demodulize.camelize(:lower).gsub(/Error/, ''),
+        additional_info
+      ]
+    end
+  end
+end

--- a/lib/logux/policy_caller.rb
+++ b/lib/logux/policy_caller.rb
@@ -15,13 +15,13 @@ module Logux
       policy_class = class_finder.find_policy_class
       @policy = policy_class.new(action: action, meta: meta)
       policy.public_send("#{action.action_type}?")
-    rescue Logux::NoPolicyError => e
+    rescue Logux::UnknownActionError, Logux::UnknownChannelError => e
       raise e if Logux.configuration.verify_authorized
       Logux.logger.warn(e)
     end
 
     def class_finder
-      @class_finder ||= Logux::ClassFinder.new(action)
+      @class_finder ||= Logux::ClassFinder.new(action: action, meta: meta)
     end
   end
 end

--- a/spec/dummy/app/logux/policies/actions/policy_without_action.rb
+++ b/spec/dummy/app/logux/policies/actions/policy_without_action.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Policies
+  module Actions
+    class PolicyWithoutAction < Logux::Policy
+      def create?
+        true
+      end
+    end
+  end
+end

--- a/spec/dummy/app/logux/policies/channels/policy_without_channel.rb
+++ b/spec/dummy/app/logux/policies/channels/policy_without_channel.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Policies
+  module Channels
+    class PolicyWithoutChannel < Logux::Policy
+      def subscribe?
+        true
+      end
+    end
+  end
+end

--- a/spec/factories/logux_actions_factory.rb
+++ b/spec/factories/logux_actions_factory.rb
@@ -18,5 +18,14 @@ FactoryBot.define do
       key { 'name' }
       value { 'test1' }
     end
+
+    factory :logux_actions_unknown do
+      type 'unknown/action'
+    end
+
+    factory :logux_actions_unknown_subscribe do
+      type 'logux/subscribe'
+      channel 'unknown/channel'
+    end
   end
 end

--- a/spec/logux/action_caller_spec.rb
+++ b/spec/logux/action_caller_spec.rb
@@ -8,10 +8,6 @@ describe Logux::ActionCaller do
   let(:meta) { create(:logux_meta) }
 
   describe '#call!' do
-    it 'raise error' do
-      expect { action_caller.call! }.to raise_error(Logux::NoActionError)
-    end
-
     context 'when action defined' do
       subject(:result) { action_caller.call! }
 

--- a/spec/logux/class_finder_spec.rb
+++ b/spec/logux/class_finder_spec.rb
@@ -3,12 +3,13 @@
 require 'spec_helper'
 
 describe Logux::ClassFinder do
-  let(:finder) { described_class.new(params) }
+  let(:finder) { described_class.new(action: action, meta: meta) }
+  let(:meta) { create(:logux_meta) }
 
   describe '#class_name' do
     subject(:class_name) { finder.class_name }
 
-    let(:params) { create(:logux_actions_add, type: 'test/test/name/try/user/add') }
+    let(:action) { create(:logux_actions_add, type: 'test/test/name/try/user/add') }
 
     it 'returns nested classes' do
       expect(class_name).to eq('Test::Test::Name::Try::User')
@@ -18,10 +19,40 @@ describe Logux::ClassFinder do
   describe '#find_policy_class' do
     subject(:policy_class) { finder.find_policy_class }
 
-    let(:params) { create(:logux_actions_add, type: 'test/test/name/try/user/add') }
+    context 'with unknown action' do
+      let(:action) { create(:logux_actions_unknown) }
 
-    it 'raise an error' do
-      expect { policy_class }.to raise_error(Logux::NoPolicyError)
+      it 'raise an error for unknown action error' do
+        expect { policy_class }.to raise_error(Logux::UnknownActionError)
+      end
+    end
+
+    context 'with unknown subscribe' do
+      let(:action) { create(:logux_actions_unknown_subscribe) }
+
+      it 'raise an error for unknown action error' do
+        expect { policy_class }.to raise_error(Logux::UnknownChannelError)
+      end
+    end
+  end
+
+  describe '#find_action_class' do
+    subject(:action_class) { finder.find_action_class }
+
+    context 'with unknown action' do
+      let(:action) { create(:logux_actions_unknown) }
+
+      it 'raise an error for unknown action error' do
+        expect { action_class }.to raise_error(Logux::UnknownActionError)
+      end
+    end
+
+    context 'with unknown subscribe' do
+      let(:action) { create(:logux_actions_unknown_subscribe) }
+
+      it 'raise an error for unknown action error' do
+        expect { action_class }.to raise_error(Logux::UnknownChannelError)
+      end
     end
   end
 end

--- a/spec/logux/error_renderer_spec.rb
+++ b/spec/logux/error_renderer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Logux::ErrorRenderer do
+  let(:meta) { create(:logux_meta, id: 123) }
+
+  describe '#message' do
+    def build_message(exception)
+      described_class.new(exception).message
+    end
+
+    it 'returns correct error message for UnknownActionError' do
+      exception = Logux::UnknownActionError.new('test', meta: meta)
+
+      expect(build_message(exception)).to eq(['unknownAction', 123])
+    end
+
+    it 'returns correct error message for UnknownChannelError' do
+      exception = Logux::UnknownChannelError.new('test', meta: meta)
+
+      expect(build_message(exception)).to eq(['unknownChannel', 123])
+    end
+
+    it 'returns correct error message for UnauthorizedError' do
+      exception = Logux::UnauthorizedError.new('test')
+
+      expect(build_message(exception)).to eq(%w[unauthorized test])
+    end
+
+    it 'returns correct error message for some unknown error' do
+      exception = StandardError.new
+
+      expect(build_message(exception)).to eq(
+        ['error', 'Please look server logs for more information']
+      )
+    end
+  end
+end


### PR DESCRIPTION
It is [alternative](https://github.com/wilddima/logux_rails/pull/12) implementation of solving https://github.com/wilddima/logux_rails/issues/7
There is a problem with @NikitaNaumenko approach that `PolicyCaller` is now knowing to much about streams. And reason that we need some how to combine meta information and error reason and render it to the stream.
So I decide to save some meta information in exception itself and dig it in place where now errors handles https://github.com/wilddima/logux_rails/pull/12#discussion_r221425889. Thx @wilddima for idea.