### PR TITLE
Enable sending backtrace by default

### DIFF
--- a/lib/logux.rb
+++ b/lib/logux.rb
@@ -62,7 +62,7 @@ module Logux
     end
     config.on_error = proc {}
     config.auth_rule = proc { false }
-    config.render_backtrace_on_error = false
+    config.render_backtrace_on_error = true
   end
 
   def self.add(type, meta: {})


### PR DESCRIPTION
1. Документацию никто не читает. Большинство пользователей не будут знать об этой очень полезной фиче.
2. Логакс-сервер сейчас и так не посылает ошибку в консоль браузера, если запущен в режиме разработки.